### PR TITLE
fix write timestamp seconds

### DIFF
--- a/firmware/inc/harp_core.h
+++ b/firmware/inc/harp_core.h
@@ -432,6 +432,26 @@ protected:
 
 private:
 /**
+ * \brief recompute the next heartbeat event time based on the current time.
+ * \note curr time (in microseconds) is specified in 32-bit (truncated)
+ *  representation of harp time.
+ */
+    static inline void update_next_heartbeat_from_curr_time_us(
+        uint32_t curr_harp_time_us32)
+    {
+        // Recompute next whole second (in [us]) based on synchronized time.
+        // Round *up* to the nearest whole second.
+#if defined(PICO_RP2040) // Invoke pico-specific fast-integer-division hardware.
+        uint32_t remainder;
+        uint32_t quotient = divmod_u32u32_rem(curr_harp_time_us32, 1'000'000UL,
+                                              &remainder);
+ #else
+        uint32_t remainder = curr_harp_time_us32 % 1'000'000UL;
+ #endif
+        self->next_heartbeat_time_us_ = curr_harp_time_us32 - remainder
+                                        + self->heartbeat_interval_us_;
+    }
+/**
  * \brief the total number of bytes read into the the msg receive buffer.
  *  This is implemented as a read-only reference to the #rx_buffer_index_.
  */

--- a/firmware/inc/harp_core.h
+++ b/firmware/inc/harp_core.h
@@ -433,23 +433,22 @@ protected:
 private:
 /**
  * \brief recompute the next heartbeat event time based on the current time.
- * \note curr time (in microseconds) is specified in 32-bit (truncated)
- *  representation of harp time.
  */
-    static inline void update_next_heartbeat_from_curr_time_us(
-        uint32_t curr_harp_time_us32)
+    static inline void update_next_heartbeat_from_curr_harp_time_us(
+        uint64_t curr_harp_time_us)
     {
         // Recompute next whole second (in [us]) based on synchronized time.
         // Round *up* to the nearest whole second.
 #if defined(PICO_RP2040) // Invoke pico-specific fast-integer-division hardware.
-        uint32_t remainder;
-        uint32_t quotient = divmod_u32u32_rem(curr_harp_time_us32, 1'000'000UL,
+        uint64_t remainder;
+        uint64_t quotient = divmod_u64u64_rem(curr_harp_time_us, 1'000'000ULL,
                                               &remainder);
  #else
-        uint32_t remainder = curr_harp_time_us32 % 1'000'000UL;
+        uint64_t remainder = curr_harp_time_us % 1'000'000ULL;
  #endif
-        self->next_heartbeat_time_us_ = curr_harp_time_us32 - remainder
-                                        + self->heartbeat_interval_us_;
+        self->next_heartbeat_time_us_ =
+            harp_to_system_us_32(curr_harp_time_us - remainder)
+            + self->heartbeat_interval_us_;
     }
 /**
  * \brief the total number of bytes read into the the msg receive buffer.
@@ -479,6 +478,8 @@ private:
 /**
  * \brief next time a heartbeat message is scheduled to issue.
  * \note only valid if Op Mode is in the ACTIVE state.
+ * \note this value is currently specified in 32-bit local system time
+ *  since it is a short interval.
  */
     uint32_t next_heartbeat_time_us_;
 
@@ -491,6 +492,8 @@ private:
 /**
  * \brief last time device detects no connection with the PC in microseconds.
  * \note only valid if Op Mode is not in STANDBY mode.
+ * \note this value is currently specified in 32-bit local system time
+ *  since it is a short interval.
  */
     uint32_t disconnect_start_time_us_;
 

--- a/firmware/src/harp_core.cpp
+++ b/firmware/src/harp_core.cpp
@@ -45,17 +45,7 @@ HarpCore::HarpCore(uint16_t who_am_i,
 #pragma warning("Harp Core Register UUID not autodetected for this board.")
 #endif
     // Initialize next heartbeat.
-    // Round *up* to the nearest whole second.
-#if defined(PICO_RP2040)
-    uint32_t curr_time_us = uint32_t(harp_time_us_64());
-    uint32_t remainder;
-    uint32_t quotient = divmod_u32u32_rem(curr_time_us, 1'000'000UL,
-                                          &remainder);
-#else
-    uint32_t remainder = curr_time_us % 1'000'000UL;
-#endif
-    self->next_heartbeat_time_us_ = curr_time_us - remainder
-                                    + heartbeat_interval_us_;
+    update_next_heartbeat_from_curr_time_us(uint32_t(harp_time_us_64()));
 }
 
 HarpCore::~HarpCore(){self = nullptr;}
@@ -169,7 +159,7 @@ void HarpCore::handle_buffered_core_message()
 void HarpCore::update_state(bool force, op_mode_t forced_next_state)
 {
     // Update internal logic.
-    uint32_t curr_time_us = uint32_t(harp_time_us_64());
+    uint32_t curr_harp_time_us32 = uint32_t(harp_time_us_64());
     bool tud_cdc_is_connected = tud_cdc_connected(); // Compute this once.
     bool is_synced = self->is_synced(); // Compute this once
     // Preserve flag value when synced; clear flag if we unsync.
@@ -184,22 +174,12 @@ void HarpCore::update_state(bool force, op_mode_t forced_next_state)
     if (!tud_cdc_is_connected && !self->disconnect_handled_)
     {
         self->disconnect_handled_ = true;
-        self->disconnect_start_time_us_ = curr_time_us;
+        self->disconnect_start_time_us_ = curr_harp_time_us32;
     }
     // Extra logic to handle behavior that happens upon synchronizing.
     if (is_synced && !self->sync_handled_)
     {
-        // Recompute next whole second (in [us]) based on synchronized time.
-        // Round *up* to the nearest whole second.
-#if defined(PICO_RP2040)
-        uint32_t remainder;
-        uint32_t quotient = divmod_u32u32_rem(curr_time_us, 1'000'000UL,
-                                              &remainder);
-#else
-        uint32_t remainder = curr_time_us % 1'000'000UL;
-#endif
-        self->next_heartbeat_time_us_ = curr_time_us - remainder
-                                        + self->heartbeat_interval_us_;
+        update_next_heartbeat_from_curr_time_us(curr_harp_time_us32);
         self->sync_handled_ = true;
     }
     // Update state machine "next-state" logic.
@@ -215,7 +195,8 @@ void HarpCore::update_state(bool force, op_mode_t forced_next_state)
             case ACTIVE:
                 // Drop to STANDBY if we've lost the PC connection for too long.
                 if (!tud_cdc_is_connected && self->disconnect_handled_
-                    && (curr_time_us - self->disconnect_start_time_us_) >= NO_PC_INTERVAL_US)
+                    && (curr_harp_time_us32 - self->disconnect_start_time_us_)
+                       >= NO_PC_INTERVAL_US)
                     next_state = STANDBY;
                 break;
             case RESERVED:
@@ -238,7 +219,7 @@ void HarpCore::update_state(bool force, op_mode_t forced_next_state)
         self->heartbeat_interval_us_ = HEARTBEAT_STANDBY_INTERVAL_US;
     }
     // Handle OPERATION_CTRL behavior.
-    if (int32_t(curr_time_us - self->next_heartbeat_time_us_) >= 0)
+    if (int32_t(curr_harp_time_us32 - self->next_heartbeat_time_us_) >= 0)
     {
         self->next_heartbeat_time_us_ += self->heartbeat_interval_us_;
         // Dispatch heartbeat msg and Blink LED.
@@ -395,6 +376,9 @@ void HarpCore::write_timestamp_second(msg_t& msg)
 #endif
     uint64_t new_harp_time_us = set_time_microseconds + curr_microseconds;
     set_harp_time_us_64(new_harp_time_us);
+    // Update time-dependent behavior. Take harp time from this function to
+    // enable external synchronizer to take priority.
+    update_next_heartbeat_from_curr_time_us(uint32_t(harp_time_us_64()));
     // Send harp reply.
     // Note: harp timestamp registers will be updated before being dispatched.
     send_harp_reply(WRITE, msg.header.address);
@@ -420,6 +404,9 @@ void HarpCore::write_timestamp_microsecond(msg_t& msg)
 #endif
     uint64_t new_harp_time_us = curr_total_s + msg_us;
     set_harp_time_us_64(new_harp_time_us);
+    // Update time-dependent behavior. Take harp time from this function to
+    // enable external synchronizer to take priority.
+    update_next_heartbeat_from_curr_time_us(uint32_t(harp_time_us_64()));
     // Send harp reply.
     // Note: Harp timestamp registers will be updated before dispatching reply.
     send_harp_reply(WRITE, msg.header.address);

--- a/tests/enable_heartbeat.py
+++ b/tests/enable_heartbeat.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+from enum import Enum
+from pyharp.device import Device, DeviceMode
+from pyharp.messages import HarpMessage
+from pyharp.messages import MessageType
+from pyharp.messages import CommonRegisters as CoreRegs
+from struct import *
+from time import perf_counter as now
+
+COM_PORT = "/dev/ttyACM0" # COMxx on Windows.
+
+device = Device(COM_PORT, "ibl.bin")
+
+
+# Enable heartbeat
+print("Enabling heartbeat.")
+device.enable_heartbeat()
+
+start_time_s = now()
+duration_s = 3
+
+while now() - start_time_s < duration_s:
+    event_reply = device._read()
+    if event_reply is not None:
+        print()
+        print(event_reply)
+
+# Cleanup:
+print("Disabling heartbeat.")
+device.disable_heartbeat()

--- a/tests/update_local_time.py
+++ b/tests/update_local_time.py
@@ -18,7 +18,7 @@ curr_time_s = device.send(HarpMessage.ReadU32(
 print(f"Current seconds: {curr_time_s}")
 
 # Update Harp time on the device.
-set_time_seconds = 1000
+set_time_seconds = int(3e9)
 print(f"Setting Harp seconds to {set_time_seconds}")
 _ = device.send(HarpMessage.WriteU32(CoreRegs.TIMESTAMP_SECOND,
                                      set_time_seconds).frame)

--- a/tests/update_local_time.py
+++ b/tests/update_local_time.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+from enum import Enum
+from pyharp.device import Device, DeviceMode
+from pyharp.messages import HarpMessage
+from pyharp.messages import MessageType
+from pyharp.messages import CommonRegisters as CoreRegs
+from struct import *
+from time import sleep, perf_counter
+
+COM_PORT = "/dev/ttyACM0" # COMxx on Windows.
+
+device = Device(COM_PORT, "ibl.bin")
+
+
+# Get the old time.
+curr_time_s = device.send(HarpMessage.ReadU32(
+                            CoreRegs.TIMESTAMP_SECOND).frame).payload[0]
+print(f"Current seconds: {curr_time_s}")
+
+# Update Harp time on the device.
+set_time_seconds = 1000
+print(f"Setting Harp seconds to {set_time_seconds}")
+_ = device.send(HarpMessage.WriteU32(CoreRegs.TIMESTAMP_SECOND,
+                                     set_time_seconds).frame)
+sleep(1)
+
+# Get the new time from the device:
+new_time_s = device.send(HarpMessage.ReadU32(
+                            CoreRegs.TIMESTAMP_SECOND).frame).payload[0]
+print(f"Updated seconds: {new_time_s}")
+


### PR DESCRIPTION
# Summary
* Fixes https://github.com/AllenNeuralDynamics/harp.core.pico/issues/42
* We can now write to the TIMESTAMP_SECONDS register and cause the device to take the new time
# Details
The main issue was a reinterpret-cast from the payload (uint32) causing the device to crash (likely bc of alignment)
* Also removes awareness of the synchronizer in the implementation (cpp) file, since it is abstracted out in another function.
* added two pyharp scripts to validate behavior.