### PR TITLE
Feat infer harp version

### DIFF
--- a/firmware/inc/harp_c_app.h
+++ b/firmware/inc/harp_c_app.h
@@ -5,7 +5,7 @@
 #include <reg_types.h>
 
 /**
- * \brief Harp C-style App that handles core behaviors in addition t
+ * \brief Harp C-style App that handles core behaviors in addition to
 *   reads/writes to app-specific registers.
 *   Implemented as a singleton to simplify attaching interrupt callbacks
 *   (and since you can only have one per device).

--- a/firmware/inc/harp_c_app.h
+++ b/firmware/inc/harp_c_app.h
@@ -17,11 +17,8 @@ class HarpCApp: public HarpCore
 private:
 /**
  * \brief constructor
- * \param app_reg_values pointer to struct containing registers.
  * \param app_reg_specs array of reg specs, indexed by app register address.
  * \param app_register_count number of app registers
- * \param reg_fns array of RegFnPairs {read fn ptr, write fn ptr}, indexed by
- *  register address.
  * \param app_reg_count number of app registers.
  * \param update_fn pointer to function that will be called periodically to
  *  update the app state.
@@ -30,7 +27,6 @@ private:
     HarpCApp(uint16_t who_am_i,
              uint8_t hw_version_major, uint8_t hw_version_minor,
              uint8_t assembly_version,
-             uint8_t harp_version_major, uint8_t harp_version_minor,
              uint8_t fw_version_major, uint8_t fw_version_minor,
              uint16_t serial_number, const char name[],
              const uint8_t tag[],
@@ -50,7 +46,6 @@ public:
     static HarpCApp& init(uint16_t who_am_i,
                           uint8_t hw_version_major, uint8_t hw_version_minor,
                           uint8_t assembly_version,
-                          uint8_t harp_version_major, uint8_t harp_version_minor,
                           uint8_t fw_version_major, uint8_t fw_version_minor,
                           uint16_t serial_number, const char name[],
                           const uint8_t tag[],

--- a/firmware/inc/harp_core.h
+++ b/firmware/inc/harp_core.h
@@ -64,7 +64,6 @@ protected: // protected, but not private, to enable derived class usage.
     HarpCore(uint16_t who_am_i,
              uint8_t hw_version_major, uint8_t hw_version_minor,
              uint8_t assembly_version,
-             uint8_t harp_version_major, uint8_t harp_version_minor,
              uint8_t fw_version_major, uint8_t fw_version_minor,
              uint16_t serial_number, const char name[],
              const uint8_t tag[]);
@@ -87,7 +86,6 @@ public:
     static HarpCore& init(uint16_t who_am_i,
                           uint8_t hw_version_major, uint8_t hw_version_minor,
                           uint8_t assembly_version,
-                          uint8_t harp_version_major, uint8_t harp_version_minor,
                           uint8_t fw_version_major, uint8_t fw_version_minor,
                           uint16_t serial_number, const char name[],
                           const uint8_t tag[]);

--- a/firmware/src/harp_c_app.cpp
+++ b/firmware/src/harp_c_app.cpp
@@ -3,7 +3,6 @@
 HarpCApp& HarpCApp::init(uint16_t who_am_i,
                          uint8_t hw_version_major, uint8_t hw_version_minor,
                          uint8_t assembly_version,
-                         uint8_t harp_version_major, uint8_t harp_version_minor,
                          uint8_t fw_version_major, uint8_t fw_version_minor,
                          uint16_t serial_number, const char name[],
                          const uint8_t tag[],
@@ -12,7 +11,6 @@ HarpCApp& HarpCApp::init(uint16_t who_am_i,
 {
     static HarpCApp app(who_am_i, hw_version_major, hw_version_minor,
                         assembly_version,
-                        harp_version_major, harp_version_minor,
                         fw_version_major, fw_version_minor, serial_number,
                         name, tag, app_reg_specs, app_reg_count, update_fn,
                         reset_fn);
@@ -22,7 +20,6 @@ HarpCApp& HarpCApp::init(uint16_t who_am_i,
 HarpCApp::HarpCApp(uint16_t who_am_i,
                    uint8_t hw_version_major, uint8_t hw_version_minor,
                    uint8_t assembly_version,
-                   uint8_t harp_version_major, uint8_t harp_version_minor,
                    uint8_t fw_version_major, uint8_t fw_version_minor,
                    uint16_t serial_number, const char name[],
                    const uint8_t tag[],
@@ -32,8 +29,7 @@ HarpCApp::HarpCApp(uint16_t who_am_i,
  app_reg_count_{app_reg_count},
  update_fn_{update_fn},
  reset_fn_{reset_fn},
- HarpCore(who_am_i, hw_version_major, hw_version_minor,
-          assembly_version, harp_version_major, harp_version_minor,
+ HarpCore(who_am_i, hw_version_major, hw_version_minor, assembly_version,
           fw_version_major, fw_version_minor, serial_number, name, tag)
 {
     // Call base class constructor.

--- a/firmware/src/harp_core.cpp
+++ b/firmware/src/harp_core.cpp
@@ -3,7 +3,6 @@
 HarpCore& HarpCore::init(uint16_t who_am_i,
                          uint8_t hw_version_major, uint8_t hw_version_minor,
                          uint8_t assembly_version,
-                         uint8_t harp_version_major, uint8_t harp_version_minor,
                          uint8_t fw_version_major, uint8_t fw_version_minor,
                          uint16_t serial_number, const char name[],
                          const uint8_t tag[])
@@ -11,7 +10,6 @@ HarpCore& HarpCore::init(uint16_t who_am_i,
     // Create the singleton instance using the private constructor.
     static HarpCore core(who_am_i, hw_version_major, hw_version_minor,
                          assembly_version,
-                         harp_version_major, harp_version_minor,
                          fw_version_major, fw_version_minor, serial_number,
                          name, tag);
     return core;
@@ -20,12 +18,11 @@ HarpCore& HarpCore::init(uint16_t who_am_i,
 HarpCore::HarpCore(uint16_t who_am_i,
                    uint8_t hw_version_major, uint8_t hw_version_minor,
                    uint8_t assembly_version,
-                   uint8_t harp_version_major, uint8_t harp_version_minor,
                    uint8_t fw_version_major, uint8_t fw_version_minor,
                    uint16_t serial_number, const char name[],
                    const uint8_t tag[])
 :regs_{who_am_i, hw_version_major, hw_version_minor, assembly_version,
-       harp_version_major, harp_version_minor,
+       HARP_VERSION_MAJOR, HARP_VERSION_MINOR,
        fw_version_major, fw_version_minor, serial_number, name, tag},
  rx_buffer_index_{0}, total_bytes_read_{rx_buffer_index_}, new_msg_{false},
  set_visual_indicators_fn_{nullptr}, sync_{nullptr}, offset_us_64_{0},


### PR DESCRIPTION
Originally, we would pass the harp protocol version numbers into the `HarpCApp` class constructor. But these numbers reflect the current implemented harp protocol, so they should be fixed and hidden.