### PR TITLE
example cleanup; rename read/write-only convenience funcs

### DIFF
--- a/examples/harp_c_app_example/src/main.cpp
+++ b/examples/harp_c_app_example/src/main.cpp
@@ -13,14 +13,9 @@ const uint16_t who_am_i = 1234;
 const uint8_t hw_version_major = 1;
 const uint8_t hw_version_minor = 0;
 const uint8_t assembly_version = 2;
-const uint8_t harp_version_major = 2;
-const uint8_t harp_version_minor = 0;
 const uint8_t fw_version_major = 3;
 const uint8_t fw_version_minor = 0;
 const uint16_t serial_number = 0xCAFE;
-
-// Harp App Register Setup.
-const size_t app_reg_count = 2;
 
 // Define register contents.
 struct RegData
@@ -30,13 +25,16 @@ struct RegData
 } reg_data;
 
 // Define register "specs."
-RegSpec app_reg_specs[app_reg_count]
+RegSpec app_reg_specs[]
 {
     RegSpec::U8(&reg_data.test_byte,
         HarpCore::read_reg_generic, HarpCore::write_reg_generic),
     RegSpec::U32(&reg_data.test_uint,
-        HarpCore::read_reg_generic, HarpCore::write_to_read_only_reg_error)
+        HarpCore::read_reg_generic, HarpCore::write_reg_error) // read-only reg
 };
+
+const size_t app_reg_count = sizeof(app_reg_specs);
+
 
 void app_reset()
 {
@@ -55,12 +53,10 @@ void update_app_state()
 // Create Harp App.
 HarpCApp& app = HarpCApp::init(who_am_i, hw_version_major, hw_version_minor,
                                assembly_version,
-                               harp_version_major, harp_version_minor,
                                fw_version_major, fw_version_minor,
                                serial_number, "Example C App",
                                (const uint8_t*)GIT_HASH, // in CMakeLists.txt.
-                               app_reg_specs,
-                               app_reg_count, update_app_state,
+                               app_reg_specs, app_reg_count, update_app_state,
                                app_reset);
 
 // Core0 main.
@@ -71,7 +67,7 @@ int main()
     app.set_synchronizer(&sync);
 #ifdef DEBUG
     stdio_uart_init_full(uart0, 921600, 0, -1); // use uart1 tx only.
-    printf("Hello, from an RP2040!\r\n");
+    printf("Hello, from a Pi Pico!\r\n");
 #endif
     while(true)
     {

--- a/firmware/inc/harp_core.h
+++ b/firmware/inc/harp_core.h
@@ -148,15 +148,19 @@ public:
  *  indicate a read error.
  * \note This function is provided for convenience where no payload is
  *  necessary. For alternate circumstances where a specific payload must be
- *  used, invoke send_harp_reply() instead.
+ *  included, invoke send_harp_reply() directly instead.
  */
-    static void read_from_write_only_reg_error(uint8_t reg_name);
+    static void read_reg_error(uint8_t reg_name);
 
 /**
- * \brief write-error handler function. Send a harp reply indicating a write
- *  error to the specified register.
+ * \brief write-error handler function. Send a zero-length payload harp reply
+ *  from the specified register with the reply type set as `WRITE_ERROR` to
+ *  indicate a write error.
+ * \note This function is provided for convenience where no payload is
+ *  necessary. For alternate circumstances where a specific payload must be
+ *  included, invoke send_harp_reply() directly instead.
  */
-    static void write_to_read_only_reg_error(msg_t& msg);
+    static void write_reg_error(msg_t& msg);
 
 
 /**
@@ -610,21 +614,21 @@ private:
     //  so we can't index into them directly via enum value.
     const RegSpec core_reg_specs_[CORE_REG_COUNT] =
     {RegSpec::U16((void*)&regs_.R_WHO_AM_I,
-                  read_reg_generic, write_to_read_only_reg_error),
+                  read_reg_generic, write_reg_error),
      RegSpec::U8((void*)&regs_.R_HW_VERSION_H,
-                 read_reg_generic, write_to_read_only_reg_error),
+                 read_reg_generic, write_reg_error),
      RegSpec::U8((void*)&regs_.R_HW_VERSION_L,
-                 read_reg_generic, write_to_read_only_reg_error),
+                 read_reg_generic, write_reg_error),
      RegSpec::U8((void*)&regs_.R_ASSEMBLY_VERSION,
-                 read_reg_generic, write_to_read_only_reg_error),
+                 read_reg_generic, write_reg_error),
      RegSpec::U8((void*)&regs_.R_HARP_VERSION_H,
-                 read_reg_generic, write_to_read_only_reg_error),
+                 read_reg_generic, write_reg_error),
      RegSpec::U8((void*)&regs_.R_HARP_VERSION_L,
-                 read_reg_generic, write_to_read_only_reg_error),
+                 read_reg_generic, write_reg_error),
      RegSpec::U8((void*)&regs_.R_FW_VERSION_H,
-                 read_reg_generic, write_to_read_only_reg_error),
+                 read_reg_generic, write_reg_error),
      RegSpec::U8((void*)&regs_.R_FW_VERSION_L,
-                 read_reg_generic, write_to_read_only_reg_error),
+                 read_reg_generic, write_reg_error),
      RegSpec::U32(&regs_.R_TIMESTAMP_SECOND,
                   read_timestamp_second, write_timestamp_second),
      RegSpec::U16(&regs_.R_TIMESTAMP_MICRO,
@@ -642,9 +646,9 @@ private:
      RegSpec::U8(&regs_.R_TIMESTAMP_OFFSET,
                  read_reg_generic, write_reg_generic),
      RegSpec::U8Array(&regs_.R_UUID, sizeof(regs_.R_UUID),
-                      read_uuid, write_to_read_only_reg_error),
+                      read_uuid, write_reg_error),
      RegSpec::U8Array(&regs_.R_TAG, sizeof(regs_.R_TAG),
-                      read_reg_generic, write_to_read_only_reg_error),
+                      read_reg_generic, write_reg_error),
     };
 };
 

--- a/firmware/src/harp_core.cpp
+++ b/firmware/src/harp_core.cpp
@@ -311,21 +311,23 @@ void HarpCore::write_reg_generic(msg_t& msg)
                     spec.payload_type);
 }
 
-void HarpCore::write_to_read_only_reg_error(msg_t& msg)
+void HarpCore::write_reg_error(msg_t& msg)
 {
 #ifdef DEBUG_HARP_MSG_IN
     printf("Error: Reg address %d is read-only.\r\n", msg.header.address);
 #endif
-    send_harp_reply(WRITE_ERROR, msg.header.address);
+    const RegSpec& spec = self->reg_address_to_spec(msg.header.address);
+    send_harp_reply(WRITE_ERROR, msg.header.address, nullptr, 0, spec.payload_type);
 }
 
-void HarpCore::read_from_write_only_reg_error(uint8_t address)
+void HarpCore::read_reg_error(uint8_t address)
 {
 #ifdef DEBUG_HARP_MSG_IN
     printf("Error: Reg address %d is write-only.\r\n", address);
 #endif
     // Send a zero-length reply to keep the transaction short.
-    send_harp_reply(READ_ERROR, address, nullptr, 0, U8);
+    const RegSpec& spec = self->reg_address_to_spec(address);
+    send_harp_reply(READ_ERROR, address, nullptr, 0, spec.payload_type);
 }
 
 inline void HarpCore::set_timestamp_regs(uint64_t harp_time_us)


### PR DESCRIPTION
This PR:
* fixes the Harp Example so it compiles under the new API
* renames the read-only and write-only convenience functions.
  * update their docs

This is hopefully the last bit of tiding up before merging everything into main and making a release on the upstream Harp-Tech repo.