### PR TITLE
Extended-length register write support 

### DIFF
--- a/firmware/inc/harp_c_app.h
+++ b/firmware/inc/harp_c_app.h
@@ -65,9 +65,10 @@ private:
 /**
  * \brief Dispatch an incoming extended-length message to the appropriate app register's
  *  extended write handler.
- * \details Called from HarpCore::run() when new_ext_msg_ is set. Performs
- *  address range-checking, looks up the write_ext_fn_ptr from the register's
- *  RegSpec, and invokes it. Drains and discards payload bytes before sending
+ * \details Called from HarpCore::run() when new_msg() is true and
+ *  get_buffered_msg_type() == msg_type_t::BLOB. Performs
+ *  address range-checking, casts write_fn_ptr to write_ext_reg_fn for blob registers,
+ *  and invokes it. Drains and discards payload bytes before sending
  *  a WRITE_ERROR reply for out-of-range or non-extended-capable registers.
  */
     void handle_buffered_ext_app_message() override;

--- a/firmware/inc/harp_c_app.h
+++ b/firmware/inc/harp_c_app.h
@@ -63,6 +63,16 @@ private:
     void handle_buffered_app_message();
 
 /**
+ * \brief Dispatch an incoming extended-length message to the appropriate app register's
+ *  extended write handler.
+ * \details Called from HarpCore::run() when new_ext_msg_ is set. Performs
+ *  address range-checking, looks up the write_ext_fn_ptr from the register's
+ *  RegSpec, and invokes it. Drains and discards payload bytes before sending
+ *  a WRITE_ERROR reply for out-of-range or non-extended-capable registers.
+ */
+    void handle_buffered_ext_app_message() override;
+
+/**
  * \brief update app state. Readable registers can be updated here.
  *  Implements virtual member fn in base class of the same name.
  */

--- a/firmware/inc/harp_core.h
+++ b/firmware/inc/harp_core.h
@@ -264,8 +264,8 @@ public:
     static inline void send_harp_reply(msg_type_t reply_type, uint8_t reg_name)
     {
         const RegSpec& spec = reg_address_to_spec(reg_name);
-        send_harp_reply(reply_type, reg_name, spec.base_ptr, spec.num_bytes,
-                        spec.payload_type);
+        send_harp_reply(reply_type, reg_name, spec.base_ptr,
+                        static_cast<uint8_t>(spec.num_bytes), spec.payload_type);
     }
 
 /**
@@ -282,7 +282,8 @@ public:
                                        uint64_t harp_time_us)
     {
         const RegSpec& spec = reg_address_to_spec(reg_name);
-        send_harp_reply(reply_type, reg_name, spec.base_ptr, spec.num_bytes,
+        send_harp_reply(reply_type, reg_name, spec.base_ptr,
+                        static_cast<uint8_t>(spec.num_bytes),
                         spec.payload_type, harp_time_us);
     }
 

--- a/firmware/inc/harp_core.h
+++ b/firmware/inc/harp_core.h
@@ -130,13 +130,6 @@ public:
     {return new_msg_;}
 
 /**
- * \brief flag indicating whether or not a new extended-length message header is in the
- *  #rx_buffer_.
- */
-    bool new_ext_msg()
-    {return new_ext_msg_;}
-
-/**
  * \brief generic handler function to write a message payload to a core or
  *      app register and issue a harp reply (unless is_muted()).
  * \note this function may be used in cases where no actions must trigger from
@@ -448,12 +441,6 @@ protected:
     {new_msg_ = false;}
 
 /**
- * \brief flag that new extended-length message has been handled. Inline.
- */
-    void clear_ext_msg()
-    {new_ext_msg_ = false;}
-
-/**
  * \brief entry point for handling incoming harp messages to core registers.
  *      Dispatches message to the appropriate handler.
  */
@@ -519,13 +506,6 @@ protected:
  * \brief flag indicating whether or not a new message is in the #rx_buffer_.
  */
     bool new_msg_;
-
-/**
- * \brief flag indicating whether or not a new extended-length message header is in the
- *  #rx_buffer_. Set by process_cdc_input() once all 8 header bytes have
- *  arrived; cleared by clear_ext_msg() after the handler returns.
- */
-    bool new_ext_msg_;
 
 /**
  * \brief function pointer to function that enables/disables visual indicators.

--- a/firmware/inc/harp_core.h
+++ b/firmware/inc/harp_core.h
@@ -455,7 +455,8 @@ protected:
 
 /**
  * \brief Handle incoming extended-length messages for the derived class.
- * \details Called from run() when new_ext_msg_ is set. The 8-byte extended
+ * \details Called from run() when new_msg() is true and
+ *  get_buffered_msg_type() == msg_type_t::BLOB. The 8-byte extended
  *  header is in rx_buffer_; payload bytes must be consumed via copy_ext_chunk().
  *  Does nothing in the base class.
  */
@@ -529,6 +530,13 @@ private:
  * \return updated running CRC state.
  */
     static uint32_t crc32_update(uint32_t crc, const void* data, size_t len);
+
+/**
+ * \brief Returns the message type byte of the currently buffered message.
+ * \warning only valid if new_msg() is true.
+ */
+    inline msg_type_t get_buffered_msg_type() const
+    { return msg_type_t(rx_buffer_[0]); }
 
 /**
  * \brief recompute the next heartbeat event time based on the current time.

--- a/firmware/inc/harp_core.h
+++ b/firmware/inc/harp_core.h
@@ -172,13 +172,15 @@ public:
     static void write_reg_error(msg_t& msg);
 
 /**
- * \brief Copy up to \p max_bytes of extended-length payload from the USB CDC receive
- *  buffer into \p dest without blocking.
+ * \brief Copy up to \p max_bytes of extended-length payload from the USB CDC
+ *  receive buffer into \p dest.  Calls tud_task() and accumulates the running
+ *  CRC-32/ISO-HDLC state.
  * \param dest destination buffer to copy into.
  * \param max_bytes maximum number of bytes to copy.
- * \return number of bytes actually copied (0 if no data available).
+ * \param bytes_written set to the number of bytes actually copied (may be 0).
+ * \return true on success (including 0 bytes available); false on timeout.
  */
-    static size_t copy_ext_chunk(void* dest, size_t max_bytes);
+    static bool copy_ext_chunk(void* dest, size_t max_bytes, size_t* bytes_written);
 
 /**
  * \brief Generic extended-length write handler for registers whose payload fits
@@ -562,6 +564,19 @@ private:
  *  This is implemented as a read-only reference to the #rx_buffer_index_.
  */
     const uint8_t& total_bytes_read_;
+
+/**
+ * \brief Running CRC-32/ISO-HDLC state for the current extended-length message.
+ *  Seeded over the 8-byte header in process_cdc_input() and updated by
+ *  copy_ext_chunk() for each payload chunk.
+ */
+    uint32_t ext_crc32_state_;
+
+/**
+ * \brief Timestamp (in system microseconds) of the last successful chunk read
+ *  in an extended-length transfer.  Used by copy_ext_chunk() for timeout detection.
+ */
+    uint64_t ext_last_chunk_us_;
 
 /**
  * \brief buffer to contain data read from the serial port.

--- a/firmware/inc/harp_core.h
+++ b/firmware/inc/harp_core.h
@@ -112,7 +112,8 @@ public:
 
 /**
  * \brief return a reference to the extended-length message header in the #rx_buffer_.
- * \warning this should only be accessed if new_ext_msg() is true.
+ * \warning this should only be accessed if new_msg() is true and
+ *  get_buffered_msg_type() == msg_type_t::BLOB.
  */
     extended_msg_header_t& get_buffered_ext_msg_header()
     {return *((extended_msg_header_t*)(&rx_buffer_));}

--- a/firmware/inc/harp_core.h
+++ b/firmware/inc/harp_core.h
@@ -35,6 +35,8 @@ inline constexpr size_t HARP_VERSION_PATCH = 0;
                                         // to IDLE.
 #define HEARTBEAT_ACTIVE_INTERVAL_US (1'000'000UL)
 #define HEARTBEAT_STANDBY_INTERVAL_US (3'000'000UL)
+#define EXT_TIMEOUT_US (2'000'000UL) // Max time to wait between extended-length payload
+                                      // chunks before issuing a WRITE_ERROR.
 
 /**
  * \brief enum for easier interpretation of the OP_MODE bitfield in the
@@ -109,6 +111,13 @@ public:
     {return *((msg_header_t*)(&rx_buffer_));}
 
 /**
+ * \brief return a reference to the extended-length message header in the #rx_buffer_.
+ * \warning this should only be accessed if new_ext_msg() is true.
+ */
+    extended_msg_header_t& get_buffered_ext_msg_header()
+    {return *((extended_msg_header_t*)(&rx_buffer_));}
+
+/**
  * \brief return a reference to the message in the #rx_buffer_. Inline.
  * \warning this should only be accessed if new_msg() is true.
  */
@@ -119,6 +128,13 @@ public:
  */
     bool new_msg()
     {return new_msg_;}
+
+/**
+ * \brief flag indicating whether or not a new extended-length message header is in the
+ *  #rx_buffer_.
+ */
+    bool new_ext_msg()
+    {return new_ext_msg_;}
 
 /**
  * \brief generic handler function to write a message payload to a core or
@@ -161,6 +177,34 @@ public:
  *  included, invoke send_harp_reply() directly instead.
  */
     static void write_reg_error(msg_t& msg);
+
+/**
+ * \brief Copy up to \p max_bytes of extended-length payload from the USB CDC receive
+ *  buffer into \p dest without blocking.
+ * \param dest destination buffer to copy into.
+ * \param max_bytes maximum number of bytes to copy.
+ * \return number of bytes actually copied (0 if no data available).
+ */
+    static size_t copy_ext_chunk(void* dest, size_t max_bytes);
+
+/**
+ * \brief Generic extended-length write handler for registers whose payload fits
+ *  entirely in RAM.
+ * \details Streams the extended-length payload from USB CDC directly into the
+ *  register's backing memory (spec.base_ptr) in chunks while accumulating a
+ *  CRC-32/ISO-HDLC over all header and payload bytes.  After the payload is
+ *  complete, reads the 4-byte trailing CRC-32, verifies it, and—on success—
+ *  issues a standard WRITE reply with a U32 payload containing the computed
+ *  CRC-32.  Sends a WRITE_ERROR reply if a chunk timeout (EXT_TIMEOUT_US)
+ *  occurs or the CRC does not match.
+ * \note This function blocks in a polling loop until all payload bytes and the
+ *  trailing CRC-32 have been received or a timeout fires.  tud_task() is
+ *  called each iteration.
+ * \warning The caller must ensure spec.base_ptr points to a buffer large
+ *  enough to hold the entire payload.
+ * \param msg reference to the parsed extended-length message header (still in rx_buffer_).
+ */
+    static void write_ext_reg_generic(extended_msg_t& msg);
 
 
 /**
@@ -404,6 +448,12 @@ protected:
     {new_msg_ = false;}
 
 /**
+ * \brief flag that new extended-length message has been handled. Inline.
+ */
+    void clear_ext_msg()
+    {new_ext_msg_ = false;}
+
+/**
  * \brief entry point for handling incoming harp messages to core registers.
  *      Dispatches message to the appropriate handler.
  */
@@ -415,6 +465,23 @@ protected:
  *  harp core.
  */
     virtual void handle_buffered_app_message(){};
+
+/**
+ * \brief Handle incoming extended-length messages for the derived class.
+ * \details Called from run() when new_ext_msg_ is set. The 8-byte extended
+ *  header is in rx_buffer_; payload bytes must be consumed via copy_ext_chunk().
+ *  Does nothing in the base class.
+ */
+    virtual void handle_buffered_ext_app_message(){};
+
+/**
+ * \brief Drain and discard all remaining payload bytes (plus the trailing
+ *  4-byte CRC-32) from the USB CDC buffer for the given extended-length message.
+ * \details Used in error paths to keep the CDC stream aligned for the next
+ *  message. Aborts early if a chunk timeout fires.
+ * \param msg reference to the extended-length message whose payload should be drained.
+ */
+    static void drain_ext_payload(extended_msg_t& msg);
 
 /**
  * \brief update state of the derived class. Does nothing in the base class,
@@ -454,6 +521,13 @@ protected:
     bool new_msg_;
 
 /**
+ * \brief flag indicating whether or not a new extended-length message header is in the
+ *  #rx_buffer_. Set by process_cdc_input() once all 8 header bytes have
+ *  arrived; cleared by clear_ext_msg() after the handler returns.
+ */
+    bool new_ext_msg_;
+
+/**
  * \brief function pointer to function that enables/disables visual indicators.
  */
     void (* set_visual_indicators_fn_)(bool);
@@ -464,6 +538,18 @@ protected:
     HarpSynchronizer* sync_;
 
 private:
+/**
+ * \brief Incrementally compute CRC-32/ISO-HDLC (IEEE 802.3) over a data buffer.
+ * \details Bitwise implementation; reflected polynomial 0xEDB88320.
+ *  Initialise \p crc to 0xFFFFFFFF before the first call, then XOR the final
+ *  return value with 0xFFFFFFFF to obtain the standard CRC-32 output.
+ * \param crc running CRC state (start with 0xFFFFFFFF).
+ * \param data pointer to input bytes.
+ * \param len  number of bytes.
+ * \return updated running CRC state.
+ */
+    static uint32_t crc32_update(uint32_t crc, const void* data, size_t len);
+
 /**
  * \brief recompute the next heartbeat event time based on the current time.
  */

--- a/firmware/inc/harp_message.h
+++ b/firmware/inc/harp_message.h
@@ -20,7 +20,7 @@ enum msg_type_t: uint8_t
 /// \brief Returns true if the ExtendedLength flag (bit 4) is set in the given type byte.
 /// \details When set, the Length field is 32-bit LE and the trailing Checksum is CRC-32/ISO-HDLC.
 inline bool is_extended_length(uint8_t type_byte)
-{ return bool(type_byte & 0x10u); }
+{ return bool(type_byte & static_cast<uint8_t>(EXTENDED_LENGTH)); }
 
 
 // Byte-align struct data so we can either:

--- a/firmware/inc/harp_message.h
+++ b/firmware/inc/harp_message.h
@@ -15,6 +15,7 @@ enum msg_type_t: uint8_t
     EVENT = 3,
     READ_ERROR  = READ  | ERROR_MASK,
     WRITE_ERROR = WRITE | ERROR_MASK,
+    BLOB = WRITE | EXTENDED_LENGTH, ///< Extended-length blob WRITE (payload_type = reg_type_t::blob).
 };
 
 /// \brief Returns true if the ExtendedLength flag (bit 4) is set in the given type byte.

--- a/firmware/inc/harp_message.h
+++ b/firmware/inc/harp_message.h
@@ -7,14 +7,20 @@
 
 enum msg_type_t: uint8_t
 {
-    ERROR_MASK = 0x08,
+    ERROR_MASK      = 0x08, ///< OR'd with a base type to form an error reply.
+    EXTENDED_LENGTH = 0x10, ///< Flag (bit 4): Length is 32-bit LE; Checksum is CRC-32/ISO-HDLC.
 
-    READ = 1,
+    READ  = 1,
     WRITE = 2,
     EVENT = 3,
-    READ_ERROR = READ | ERROR_MASK,
-    WRITE_ERROR = WRITE | ERROR_MASK
+    READ_ERROR  = READ  | ERROR_MASK,
+    WRITE_ERROR = WRITE | ERROR_MASK,
 };
+
+/// \brief Returns true if the ExtendedLength flag (bit 4) is set in the given type byte.
+/// \details When set, the Length field is 32-bit LE and the trailing Checksum is CRC-32/ISO-HDLC.
+inline bool is_extended_length(uint8_t type_byte)
+{ return bool(type_byte & 0x10u); }
 
 
 // Byte-align struct data so we can either:
@@ -84,6 +90,67 @@ struct timestamped_msg_t: public msg_t
     : msg_t(header, payload, checksum),
     timestamp_sec{timestamp_sec}, timestamp_usec{timestamp_usec}
     {}
+};
+
+// Extended-length message header (8 bytes, packed).
+// When the ExtendedLength flag (bit 4) is set in the type byte, the Length
+// field is 32-bit LE and the trailing Checksum is CRC-32/ISO-HDLC.
+//
+// The semantics of raw_length are identical to msg_header_t::raw_length:
+// it counts bytes after the raw_length field itself, up to and including the
+// CRC-32.  For a write request with no timestamp and N payload bytes:
+//   raw_length = address(1) + port(1) + payload_type(1) + payload(N) + crc32(4) = N + 7
+//
+// Layout (PC -> device, write request, no timestamp):
+//   offset 0   : type        (1 B) — base type OR'd with EXTENDED_LENGTH flag
+//   offset 1-4 : raw_length  (4 B) — 32-bit LE
+//   offset 5   : address     (1 B)
+//   offset 6   : port        (1 B) — 255
+//   offset 7   : payload_type(1 B)
+//   offset 8+  : payload     (N B) — streamed, NOT buffered
+//   offset 8+N : crc32       (4 B) — CRC-32/ISO-HDLC over all preceding bytes
+#pragma pack(push, 1)
+struct extended_msg_header_t
+{
+    using enum reg_type_t;
+
+    msg_type_t type;       ///< Base type OR'd with EXTENDED_LENGTH flag.
+    uint32_t   raw_length; ///< 32-bit LE: counts address..crc32 (same semantics as msg_header_t::raw_length).
+    uint8_t    address;
+    uint8_t    port;       ///< should default to 255.
+    reg_type_t payload_type;
+
+    /// \brief True if the payload_type byte has the HAS_TIMESTAMP flag set.
+    bool has_timestamp() const
+    { return bool(std::to_underlying(payload_type) & std::to_underlying(HAS_TIMESTAMP)); }
+
+    /// \brief Underlying message type with the ExtendedLength flag masked out.
+    msg_type_t base_type() const
+    { return msg_type_t(uint8_t(type) & ~0x10u); }
+
+    /// \brief Number of payload bytes.
+    /// \details raw_length = addr(1)+port(1)+payload_type(1)+[timestamp(6)]+payload(N)+crc32(4)
+    uint32_t payload_length() const
+    { return raw_length - (has_timestamp() ? 13u : 7u); }
+
+    /// \brief Total extended message size in bytes (type + raw_length field + raw_length contents).
+    uint32_t ext_msg_size() const
+    { return 5u + raw_length; }
+};
+#pragma pack(pop)
+
+static_assert(sizeof(extended_msg_header_t) == 8,
+              "extended_msg_header_t must be exactly 8 bytes");
+
+// Reference-only convenience struct for an extended-length message.
+// Payload is NOT buffered; stream it with HarpCore::copy_ext_chunk().
+struct extended_msg_t
+{
+    extended_msg_header_t& header;
+
+    explicit extended_msg_t(extended_msg_header_t& header) : header{header} {}
+
+    uint32_t payload_length() const { return header.payload_length(); }
 };
 
 #endif // HARP_MESSAGE_H

--- a/firmware/inc/reg_spec.h
+++ b/firmware/inc/reg_spec.h
@@ -99,6 +99,11 @@ struct RegSpec
     {return RegSpec(base_ptr, num_floats * sizeof(float), reg_type_t::Float,
                     read_fn_ptr, reinterpret_cast<void(*)()>(write_fn_ptr));}
 
+    static RegSpec Blob(volatile void* const base_ptr, uint32_t num_bytes,
+                        read_reg_fn read_fn_ptr, write_ext_reg_fn write_fn_ptr)
+    {return RegSpec(base_ptr, num_bytes, reg_type_t::Blob,
+                    read_fn_ptr, reinterpret_cast<void(*)()>(write_fn_ptr));}
+
 /**
  * \brief constructor.
  */

--- a/firmware/inc/reg_spec.h
+++ b/firmware/inc/reg_spec.h
@@ -6,6 +6,7 @@
 
 using read_reg_fn = void (*)(uint8_t);
 using write_reg_fn = void (*)(msg_t& msg);
+using write_ext_reg_fn = void (*)(extended_msg_t& msg); ///< Handler for extended-length WRITE messages.
 
 
 /**
@@ -18,11 +19,12 @@ struct RegSpec
     const reg_type_t payload_type;
     read_reg_fn read_fn_ptr;
     write_reg_fn write_fn_ptr;
+    write_ext_reg_fn write_ext_fn_ptr; ///< nullptr if register is not extended-length capable.
 
     // Default Constructor
     RegSpec()
     :base_ptr{nullptr}, num_bytes{0}, payload_type{reg_type_t::U8},
-     read_fn_ptr{nullptr}, write_fn_ptr{nullptr}{}
+     read_fn_ptr{nullptr}, write_fn_ptr{nullptr}, write_ext_fn_ptr{nullptr}}{}
 
     // Assignment Operator.
     RegSpec& operator=(const RegSpec& other) = default;
@@ -105,7 +107,8 @@ struct RegSpec
             reg_type_t payload_type,
             read_reg_fn read_fn_ptr, write_reg_fn write_fn_ptr)
         :base_ptr{base_ptr}, num_bytes{num_bytes}, payload_type{payload_type},
-         read_fn_ptr{read_fn_ptr}, write_fn_ptr{write_fn_ptr}{}
+         read_fn_ptr{read_fn_ptr}, write_fn_ptr{write_fn_ptr},
+         write_ext_fn_ptr{nullptr}{}}
 };
 
 #endif //REG_SPEC_H

--- a/firmware/inc/reg_spec.h
+++ b/firmware/inc/reg_spec.h
@@ -15,16 +15,15 @@ using write_ext_reg_fn = void (*)(extended_msg_t& msg); ///< Handler for extende
 struct RegSpec
 {
     volatile void* const base_ptr;
-    const uint8_t num_bytes;
+    const uint32_t num_bytes;
     const reg_type_t payload_type;
     read_reg_fn read_fn_ptr;
-    write_reg_fn write_fn_ptr;
-    write_ext_reg_fn write_ext_fn_ptr; ///< nullptr if register is not extended-length capable.
+    void (*write_fn_ptr)(); ///< Generic fn pointer; cast to write_reg_fn or write_ext_reg_fn based on payload_type.
 
     // Default Constructor
     RegSpec()
     :base_ptr{nullptr}, num_bytes{0}, payload_type{reg_type_t::U8},
-     read_fn_ptr{nullptr}, write_fn_ptr{nullptr}, write_ext_fn_ptr{nullptr}}{}
+     read_fn_ptr{nullptr}, write_fn_ptr{nullptr}{}
 
     // Assignment Operator.
     RegSpec& operator=(const RegSpec& other) = default;
@@ -33,82 +32,81 @@ struct RegSpec
     static RegSpec U8(volatile void* const base_ptr,
                       read_reg_fn read_fn_ptr, write_reg_fn write_fn_ptr)
     {return RegSpec(base_ptr, sizeof(uint8_t), reg_type_t::U8,
-                    read_fn_ptr, write_fn_ptr);}
+                    read_fn_ptr, reinterpret_cast<void(*)()>(write_fn_ptr));}
 
-    static RegSpec U8Array(volatile void* const base_ptr, uint8_t num_bytes,
+    static RegSpec U8Array(volatile void* const base_ptr, uint32_t num_bytes,
                       read_reg_fn read_fn_ptr, write_reg_fn write_fn_ptr)
     {return RegSpec(base_ptr, num_bytes, reg_type_t::U8,
-                    read_fn_ptr, write_fn_ptr);}
+                    read_fn_ptr, reinterpret_cast<void(*)()>(write_fn_ptr));}
 
     static RegSpec S8(volatile void* const base_ptr,
                       read_reg_fn read_fn_ptr, write_reg_fn write_fn_ptr)
     {return RegSpec(base_ptr, sizeof(int8_t), reg_type_t::S8,
-                    read_fn_ptr, write_fn_ptr);}
+                    read_fn_ptr, reinterpret_cast<void(*)()>(write_fn_ptr));}
 
-    static RegSpec S8Array(volatile void* const base_ptr, uint8_t num_bytes,
+    static RegSpec S8Array(volatile void* const base_ptr, uint32_t num_bytes,
                       read_reg_fn read_fn_ptr, write_reg_fn write_fn_ptr)
     {return RegSpec(base_ptr, num_bytes, reg_type_t::S8,
-                    read_fn_ptr, write_fn_ptr);}
+                    read_fn_ptr, reinterpret_cast<void(*)()>(write_fn_ptr));}
 
     static RegSpec U16(volatile void* const base_ptr,
                        read_reg_fn read_fn_ptr, write_reg_fn write_fn_ptr)
     {return RegSpec(base_ptr, sizeof(uint16_t), reg_type_t::U16,
-                    read_fn_ptr, write_fn_ptr);}
+                    read_fn_ptr, reinterpret_cast<void(*)()>(write_fn_ptr));}
 
-    static RegSpec U16Array(volatile void* const base_ptr, uint8_t num_elements,
+    static RegSpec U16Array(volatile void* const base_ptr, uint32_t num_elements,
                       read_reg_fn read_fn_ptr, write_reg_fn write_fn_ptr)
     {return RegSpec(base_ptr, num_elements * sizeof(uint16_t), reg_type_t::U16,
-                    read_fn_ptr, write_fn_ptr);}
+                    read_fn_ptr, reinterpret_cast<void(*)()>(write_fn_ptr));}
 
     static RegSpec S16(volatile void* const base_ptr,
                        read_reg_fn read_fn_ptr, write_reg_fn write_fn_ptr)
     {return RegSpec(base_ptr, sizeof(uint16_t), reg_type_t::S16,
-                    read_fn_ptr, write_fn_ptr);}
+                    read_fn_ptr, reinterpret_cast<void(*)()>(write_fn_ptr));}
 
-    static RegSpec S16Array(volatile void* const base_ptr, uint8_t num_elements,
+    static RegSpec S16Array(volatile void* const base_ptr, uint32_t num_elements,
                       read_reg_fn read_fn_ptr, write_reg_fn write_fn_ptr)
     {return RegSpec(base_ptr, num_elements * sizeof(int16_t), reg_type_t::S16,
-                    read_fn_ptr, write_fn_ptr);}
+                    read_fn_ptr, reinterpret_cast<void(*)()>(write_fn_ptr));}
 
     static RegSpec U32(volatile void* const base_ptr,
                        read_reg_fn read_fn_ptr, write_reg_fn write_fn_ptr)
     {return RegSpec(base_ptr, sizeof(uint32_t), reg_type_t::U32,
-                    read_fn_ptr, write_fn_ptr);}
+                    read_fn_ptr, reinterpret_cast<void(*)()>(write_fn_ptr));}
 
-    static RegSpec U32Array(volatile void* const base_ptr, uint8_t num_elements,
+    static RegSpec U32Array(volatile void* const base_ptr, uint32_t num_elements,
                       read_reg_fn read_fn_ptr, write_reg_fn write_fn_ptr)
     {return RegSpec(base_ptr, num_elements * sizeof(uint32_t), reg_type_t::U32,
-                    read_fn_ptr, write_fn_ptr);}
+                    read_fn_ptr, reinterpret_cast<void(*)()>(write_fn_ptr));}
 
     static RegSpec S32(volatile void* const base_ptr,
                        read_reg_fn read_fn_ptr, write_reg_fn write_fn_ptr)
     {return RegSpec(base_ptr, sizeof(uint32_t), reg_type_t::S32,
-                    read_fn_ptr, write_fn_ptr);}
+                    read_fn_ptr, reinterpret_cast<void(*)()>(write_fn_ptr));}
 
-    static RegSpec S32Array(volatile void* const base_ptr, uint8_t num_elements,
+    static RegSpec S32Array(volatile void* const base_ptr, uint32_t num_elements,
                       read_reg_fn read_fn_ptr, write_reg_fn write_fn_ptr)
     {return RegSpec(base_ptr, num_elements * sizeof(int32_t), reg_type_t::S32,
-                    read_fn_ptr, write_fn_ptr);}
+                    read_fn_ptr, reinterpret_cast<void(*)()>(write_fn_ptr));}
 
     static RegSpec Float(volatile void* const base_ptr,
                          read_reg_fn read_fn_ptr, write_reg_fn write_fn_ptr)
     {return RegSpec(base_ptr, sizeof(uint32_t), reg_type_t::Float,
-                    read_fn_ptr, write_fn_ptr);}
+                    read_fn_ptr, reinterpret_cast<void(*)()>(write_fn_ptr));}
 
-    static RegSpec FloatArray(volatile void* const base_ptr, uint8_t num_floats,
+    static RegSpec FloatArray(volatile void* const base_ptr, uint32_t num_floats,
                       read_reg_fn read_fn_ptr, write_reg_fn write_fn_ptr)
     {return RegSpec(base_ptr, num_floats * sizeof(float), reg_type_t::Float,
-                    read_fn_ptr, write_fn_ptr);}
+                    read_fn_ptr, reinterpret_cast<void(*)()>(write_fn_ptr));}
 
 /**
  * \brief constructor.
  */
-    RegSpec(volatile void* const base_ptr, uint8_t num_bytes,
+    RegSpec(volatile void* const base_ptr, uint32_t num_bytes,
             reg_type_t payload_type,
-            read_reg_fn read_fn_ptr, write_reg_fn write_fn_ptr)
+            read_reg_fn read_fn_ptr, void (*write_fn_ptr)())
         :base_ptr{base_ptr}, num_bytes{num_bytes}, payload_type{payload_type},
-         read_fn_ptr{read_fn_ptr}, write_fn_ptr{write_fn_ptr},
-         write_ext_fn_ptr{nullptr}{}}
+         read_fn_ptr{read_fn_ptr}, write_fn_ptr{write_fn_ptr}{}
 };
 
 #endif //REG_SPEC_H

--- a/firmware/inc/reg_types.h
+++ b/firmware/inc/reg_types.h
@@ -26,7 +26,8 @@ enum class reg_type_t: uint8_t
     TimestampedS32 = HAS_TIMESTAMP | S32,
     TimestampedU64 = HAS_TIMESTAMP | U64,
     TimestampedS64 = HAS_TIMESTAMP | S64,
-    TimestampedFloat = HAS_TIMESTAMP | Float
+    TimestampedFloat = HAS_TIMESTAMP | Float,
+    Blob = 0x0D, ///< Binary large object; payload is a raw byte sequence.
 };
 
 #endif // REG_TYPES_H

--- a/firmware/src/harp_c_app.cpp
+++ b/firmware/src/harp_c_app.cpp
@@ -56,7 +56,7 @@ void HarpCApp::handle_buffered_app_message()
             app_reg_specs_[app_reg_address].read_fn_ptr(msg.header.address);
             break;
         case WRITE:
-            app_reg_specs_[app_reg_address].write_fn_ptr(msg);
+            reinterpret_cast<write_reg_fn>(app_reg_specs_[app_reg_address].write_fn_ptr)(msg);
             break;
         default:
         {
@@ -100,8 +100,10 @@ void HarpCApp::handle_buffered_ext_app_message()
     {
         case WRITE:
         {
-            write_ext_reg_fn fn =
-                app_reg_specs_[app_reg_index].write_ext_fn_ptr;
+            const RegSpec& spec = app_reg_specs_[app_reg_index];
+            write_ext_reg_fn fn = (spec.payload_type == reg_type_t::Blob)
+                ? reinterpret_cast<write_ext_reg_fn>(spec.write_fn_ptr)
+                : nullptr;
             if (fn == nullptr)
             {
                 drain_ext_payload(msg);

--- a/firmware/src/harp_c_app.cpp
+++ b/firmware/src/harp_c_app.cpp
@@ -92,7 +92,7 @@ void HarpCApp::handle_buffered_ext_app_message()
         constexpr uint32_t err_payload = 0;
         send_harp_reply(WRITE_ERROR, header.address,
                         &err_payload, sizeof(err_payload), reg_type_t::U32);
-        clear_ext_msg();
+        clear_msg();
         return;
     }
     const uint8_t app_reg_index = header.address - APP_REG_START_ADDRESS;
@@ -126,5 +126,5 @@ void HarpCApp::handle_buffered_ext_app_message()
         default:
             break;
     }
-    clear_ext_msg();
+    clear_msg();
 }

--- a/firmware/src/harp_c_app.cpp
+++ b/firmware/src/harp_c_app.cpp
@@ -70,7 +70,13 @@ void HarpCApp::dump_app_registers()
 {
     for (uint8_t address = APP_REG_START_ADDRESS;
          address < app_reg_count_ + APP_REG_START_ADDRESS; ++address)
-        reg_address_to_spec(address).read_fn_ptr(address);
+    {
+        const RegSpec& spec = reg_address_to_spec(address);
+        // Extended-length registers are excluded from DUMP by default.
+        if (spec.write_ext_fn_ptr != nullptr)
+            continue;
+        spec.read_fn_ptr(address);
+    }
 }
 
 void HarpCApp::handle_buffered_ext_app_message()
@@ -82,8 +88,10 @@ void HarpCApp::handle_buffered_ext_app_message()
         header.address >= (APP_REG_START_ADDRESS + app_reg_count_))
     {
         drain_ext_payload(msg);
-        send_harp_reply(WRITE_ERROR, header.address, nullptr, 0,
-                        header.payload_type);
+        // WRITE_ERROR for an extended-length write carries U32 0x00000000.
+        constexpr uint32_t err_payload = 0;
+        send_harp_reply(WRITE_ERROR, header.address,
+                        &err_payload, sizeof(err_payload), reg_type_t::U32);
         clear_ext_msg();
         return;
     }
@@ -97,8 +105,10 @@ void HarpCApp::handle_buffered_ext_app_message()
             if (fn == nullptr)
             {
                 drain_ext_payload(msg);
-                send_harp_reply(WRITE_ERROR, header.address, nullptr, 0,
-                                header.payload_type);
+                // WRITE_ERROR for an extended-length write carries U32 0x00000000.
+                constexpr uint32_t err_payload = 0;
+                send_harp_reply(WRITE_ERROR, header.address,
+                                &err_payload, sizeof(err_payload), reg_type_t::U32);
             }
             else
             {

--- a/firmware/src/harp_c_app.cpp
+++ b/firmware/src/harp_c_app.cpp
@@ -72,8 +72,8 @@ void HarpCApp::dump_app_registers()
          address < app_reg_count_ + APP_REG_START_ADDRESS; ++address)
     {
         const RegSpec& spec = reg_address_to_spec(address);
-        // Extended-length registers are excluded from DUMP by default.
-        if (spec.write_ext_fn_ptr != nullptr)
+        // Extended-length (blob) registers are excluded from DUMP by default.
+        if (spec.payload_type == reg_type_t::Blob)
             continue;
         spec.read_fn_ptr(address);
     }

--- a/firmware/src/harp_c_app.cpp
+++ b/firmware/src/harp_c_app.cpp
@@ -72,3 +72,47 @@ void HarpCApp::dump_app_registers()
          address < app_reg_count_ + APP_REG_START_ADDRESS; ++address)
         reg_address_to_spec(address).read_fn_ptr(address);
 }
+
+void HarpCApp::handle_buffered_ext_app_message()
+{
+    extended_msg_header_t& header = get_buffered_ext_msg_header();
+    extended_msg_t msg{header};
+    // Only app registers are extended-length-capable in this implementation.
+    if (header.address < APP_REG_START_ADDRESS ||
+        header.address >= (APP_REG_START_ADDRESS + app_reg_count_))
+    {
+        drain_ext_payload(msg);
+        send_harp_reply(WRITE_ERROR, header.address, nullptr, 0,
+                        header.payload_type);
+        clear_ext_msg();
+        return;
+    }
+    const uint8_t app_reg_index = header.address - APP_REG_START_ADDRESS;
+    switch (header.base_type())
+    {
+        case WRITE:
+        {
+            write_ext_reg_fn fn =
+                app_reg_specs_[app_reg_index].write_ext_fn_ptr;
+            if (fn == nullptr)
+            {
+                drain_ext_payload(msg);
+                send_harp_reply(WRITE_ERROR, header.address, nullptr, 0,
+                                header.payload_type);
+            }
+            else
+            {
+                fn(msg);
+            }
+            break;
+        }
+        case READ:
+            // Stub: extended reads not yet implemented.
+            send_harp_reply(READ_ERROR, header.address, nullptr, 0,
+                            header.payload_type);
+            break;
+        default:
+            break;
+    }
+    clear_ext_msg();
+}

--- a/firmware/src/harp_c_app.cpp
+++ b/firmware/src/harp_c_app.cpp
@@ -107,7 +107,9 @@ void HarpCApp::handle_buffered_ext_app_message()
             break;
         }
         case READ:
-            // Stub: extended reads not yet implemented.
+            // Rejected: READ requests MUST NOT set the ExtendedLength flag.
+            // Drain any trailing CRC bytes to keep the CDC stream aligned.
+            drain_ext_payload(msg);
             send_harp_reply(READ_ERROR, header.address, nullptr, 0,
                             header.payload_type);
             break;

--- a/firmware/src/harp_core.cpp
+++ b/firmware/src/harp_core.cpp
@@ -24,7 +24,8 @@ HarpCore::HarpCore(uint16_t who_am_i,
 :regs_{who_am_i, hw_version_major, hw_version_minor, assembly_version,
        HARP_VERSION_MAJOR, HARP_VERSION_MINOR,
        fw_version_major, fw_version_minor, serial_number, name, tag},
- rx_buffer_index_{0}, total_bytes_read_{rx_buffer_index_}, new_msg_{false},
+ rx_buffer_index_{0}, total_bytes_read_{rx_buffer_index_},
+ new_msg_{false}, new_ext_msg_{false},
  set_visual_indicators_fn_{nullptr}, sync_{nullptr}, offset_us_64_{0},
  disconnect_handled_{false}, connect_handled_{false}, sync_handled_{false},
  heartbeat_interval_us_{HEARTBEAT_STANDBY_INTERVAL_US}
@@ -45,6 +46,13 @@ void HarpCore::run()
     update_state();
     update_app_state(); // Does nothing unless a derived class implements it.
     process_cdc_input();
+    if (new_ext_msg_)
+    {
+        handle_buffered_ext_app_message();
+        if (new_ext_msg_) // Safety net: clear if the handler forgot to.
+            clear_ext_msg();
+        return;
+    }
     if (not new_msg_)
         return;
 #ifdef DEBUG_HARP_MSG_IN
@@ -82,36 +90,59 @@ void HarpCore::run()
 
 void HarpCore::process_cdc_input()
 {
-    // TODO: Consider a timeout if we never receive a fully formed message.
-    // TODO: scan for partial messages.
-    // Fetch all data in the serial port. If it's at least a header's worth,
-    // check the payload size and keep reading up to the end of the packet.
+    // Guard: preserve the extended-length header in rx_buffer_ while the handler is active.
+    if (new_ext_msg_)
+        return;
     if (not tud_cdc_available())
         return;
-    // If the header has arrived, only read up to the full payload so we can
-    // process one message at a time.
-    uint32_t max_bytes_to_read = sizeof(rx_buffer_) - rx_buffer_index_;
-    if (total_bytes_read_ >= sizeof(msg_header_t))
+    // Limit the first read to sizeof(extended_msg_header_t) bytes so we never
+    // accidentally pull payload bytes into rx_buffer_ before we know the type.
+    // For normal messages (5-byte header) this is strictly more than needed and
+    // works fine with subsequent calls to fill the payload.
+    uint32_t max_bytes_to_read;
+    if (rx_buffer_index_ == 0)
     {
-        // Reinterpret contents of the rx buffer as a message header.
-        msg_header_t& header = get_buffered_msg_header();
-        // Read only the remainder of a single harp message.
-        max_bytes_to_read = header.msg_size() - total_bytes_read_;
+        max_bytes_to_read = sizeof(extended_msg_header_t);
+    }
+    else if (is_extended_length(rx_buffer_[0]))
+    {
+        // Still accumulating the extended header; read only what remains.
+        max_bytes_to_read = sizeof(extended_msg_header_t) - rx_buffer_index_;
+    }
+    else
+    {
+        // Normal message: expand the read window once we know the full size.
+        max_bytes_to_read = sizeof(rx_buffer_) - rx_buffer_index_;
+        if (total_bytes_read_ >= sizeof(msg_header_t))
+        {
+            msg_header_t& header = get_buffered_msg_header();
+            max_bytes_to_read = header.msg_size() - total_bytes_read_;
+        }
     }
     uint32_t bytes_read = tud_cdc_read(&(rx_buffer_[rx_buffer_index_]),
                                        max_bytes_to_read);
     rx_buffer_index_ += bytes_read;
-    // See if we have a message header's worth of data yet. Baily early if not.
+    // Need at least 1 byte to inspect the type.
+    if (rx_buffer_index_ < 1)
+        return;
+    // Extended-length message path.
+    if (is_extended_length(rx_buffer_[0]))
+    {
+        if (rx_buffer_index_ >= sizeof(extended_msg_header_t))
+        {
+            rx_buffer_index_ = 0; // Reset index; header data stays in rx_buffer_.
+            new_ext_msg_ = true;
+        }
+        return; // Keep accumulating header bytes on the next call.
+    }
+    // Normal message path.
     if (total_bytes_read_ < sizeof(msg_header_t))
         return;
-    // Reinterpret contents of the rx buffer as a message header.
     msg_header_t& header = get_buffered_msg_header();
-    // Bail early if the full message (with payload) has not fully arrived.
     if (total_bytes_read_ < header.msg_size())
         return;
     rx_buffer_index_ = 0; // Reset buffer index for the next message.
     new_msg_ = true;
-    return;
 }
 
 msg_t HarpCore::get_buffered_msg()
@@ -480,4 +511,121 @@ void HarpCore::read_uuid(uint8_t reg_name)
 #pragma warning("Harp Core Register UUID not autodetected for this board.")
 #endif
     send_harp_reply(READ, reg_name);
+}
+
+size_t HarpCore::copy_ext_chunk(void* dest, size_t max_bytes)
+{
+    if (max_bytes == 0 || !tud_cdc_available())
+        return 0;
+    return tud_cdc_read(dest, max_bytes);
+}
+
+void HarpCore::drain_ext_payload(extended_msg_t& msg)
+{
+    // Drain payload bytes plus the 4-byte trailing CRC-32 so subsequent
+    // normal messages are not corrupted by leftover extended-length data.
+    uint8_t discard[64];
+    uint32_t remaining = msg.payload_length() + 4; // +4 for CRC-32
+    uint64_t last_progress_us = time_us_64();
+    while (remaining > 0)
+    {
+        tud_task();
+        const uint32_t to_read = (remaining < sizeof(discard))
+                                  ? remaining
+                                  : uint32_t(sizeof(discard));
+        const size_t drained = copy_ext_chunk(discard, to_read);
+        if (drained > 0)
+        {
+            remaining -= uint32_t(drained);
+            last_progress_us = time_us_64();
+        }
+        else if ((time_us_64() - last_progress_us) >= EXT_TIMEOUT_US)
+        {
+            break; // Give up.
+        }
+    }
+}
+
+uint32_t HarpCore::crc32_update(uint32_t crc, const void* data, size_t len)
+{
+    // CRC-32/ISO-HDLC: reflected polynomial 0xEDB88320 (normal form: 0x04C11DB7).
+    // Init: 0xFFFFFFFF.  Final XOR: 0xFFFFFFFF.  Check value: 0xCBF43926.
+    const uint8_t* p = static_cast<const uint8_t*>(data);
+    for (size_t i = 0; i < len; ++i)
+    {
+        crc ^= p[i];
+        for (int j = 0; j < 8; ++j)
+            crc = (crc >> 1) ^ (0xEDB88320u & -(crc & 1u));
+    }
+    return crc;
+}
+
+void HarpCore::write_ext_reg_generic(extended_msg_t& msg)
+{
+    const uint32_t payload_num_bytes = msg.payload_length();
+    const RegSpec& spec = reg_address_to_spec(msg.header.address);
+    uint8_t* dest = (uint8_t*)((void*)spec.base_ptr);
+    uint32_t bytes_received = 0;
+    // CRC-32 is computed over all bytes of the message up to (not including)
+    // the trailing CRC-32 field: header bytes + all payload bytes.
+    uint32_t crc = 0xFFFFFFFFu;
+    crc = crc32_update(crc, &msg.header, sizeof(extended_msg_header_t));
+    uint64_t last_progress_us = time_us_64();
+    while (bytes_received < payload_num_bytes)
+    {
+        tud_task();
+        const uint32_t bytes_remaining = payload_num_bytes - bytes_received;
+        const size_t chunk = copy_ext_chunk(dest + bytes_received,
+                                            bytes_remaining);
+        if (chunk > 0)
+        {
+            crc = crc32_update(crc, dest + bytes_received, chunk);
+            bytes_received += uint32_t(chunk);
+            last_progress_us = time_us_64();
+        }
+        else if ((time_us_64() - last_progress_us) >= EXT_TIMEOUT_US)
+        {
+            drain_ext_payload(msg); // re-sync the CDC stream.
+            send_harp_reply(WRITE_ERROR, msg.header.address, nullptr, 0,
+                            msg.header.payload_type);
+            return;
+        }
+    }
+    const uint32_t computed_crc = crc ^ 0xFFFFFFFFu;
+    // Read and verify the 4-byte trailing CRC-32.
+    uint8_t crc_buf[4];
+    size_t crc_bytes_received = 0;
+    uint64_t crc_wait_start = time_us_64();
+    while (crc_bytes_received < sizeof(crc_buf))
+    {
+        tud_task();
+        const size_t n = copy_ext_chunk(crc_buf + crc_bytes_received,
+                                        sizeof(crc_buf) - crc_bytes_received);
+        if (n > 0)
+        {
+            crc_bytes_received += n;
+            crc_wait_start = time_us_64();
+        }
+        else if ((time_us_64() - crc_wait_start) >= EXT_TIMEOUT_US)
+        {
+            send_harp_reply(WRITE_ERROR, msg.header.address, nullptr, 0,
+                            msg.header.payload_type);
+            return;
+        }
+    }
+    uint32_t received_crc;
+    memcpy(&received_crc, crc_buf, sizeof(received_crc));
+    if (computed_crc != received_crc)
+    {
+        send_harp_reply(WRITE_ERROR, msg.header.address, nullptr, 0,
+                        msg.header.payload_type);
+        return;
+    }
+    if (!is_muted())
+    {
+        // Reply payload is the CRC-32 of the request (receipt-CRC echo).
+        send_harp_reply(WRITE, msg.header.address,
+                        &computed_crc, sizeof(computed_crc),
+                        reg_type_t::U32);
+    }
 }

--- a/firmware/src/harp_core.cpp
+++ b/firmware/src/harp_core.cpp
@@ -343,8 +343,8 @@ void HarpCore::write_reg_generic(msg_t& msg)
         return;
     const uint8_t& reg_name = msg.header.address;
     const RegSpec& spec = self->reg_address_to_spec(msg.header.address);
-    send_harp_reply(WRITE, reg_name, spec.base_ptr, spec.num_bytes,
-                    spec.payload_type);
+    send_harp_reply(WRITE, reg_name, spec.base_ptr,
+                    static_cast<uint8_t>(spec.num_bytes), spec.payload_type);
 }
 
 void HarpCore::write_reg_error(msg_t& msg)
@@ -580,64 +580,53 @@ void HarpCore::write_ext_reg_generic(extended_msg_t& msg)
 {
     const uint32_t payload_num_bytes = msg.payload_length();
     const RegSpec& spec = reg_address_to_spec(msg.header.address);
-    uint8_t* dest = (uint8_t*)((void*)spec.base_ptr);
+    uint8_t* dest = static_cast<uint8_t*>(
+        const_cast<void*>(reinterpret_cast<const void*>(spec.base_ptr)));
     uint32_t bytes_received = 0;
-    // CRC-32 is computed over all bytes of the message up to (not including)
-    // the trailing CRC-32 field: header bytes + all payload bytes.
-    uint32_t crc = 0xFFFFFFFFu;
-    crc = crc32_update(crc, &msg.header, sizeof(extended_msg_header_t));
-    uint64_t last_progress_us = time_us_64();
+    // Stream payload into register backing memory.
+    // copy_ext_chunk() handles tud_task(), CRC-32 accumulation, and timeout.
     while (bytes_received < payload_num_bytes)
     {
-        tud_task();
-        const uint32_t bytes_remaining = payload_num_bytes - bytes_received;
-        const size_t chunk = copy_ext_chunk(dest + bytes_received,
-                                            bytes_remaining);
-        if (chunk > 0)
+        size_t chunk;
+        if (!copy_ext_chunk(dest + bytes_received,
+                            payload_num_bytes - bytes_received, &chunk))
         {
-            crc = crc32_update(crc, dest + bytes_received, chunk);
-            bytes_received += uint32_t(chunk);
-            last_progress_us = time_us_64();
-        }
-        else if ((time_us_64() - last_progress_us) >= EXT_TIMEOUT_US)
-        {
-            drain_ext_payload(msg); // re-sync the CDC stream.
-            // WRITE_ERROR for an extended-length write carries U32 0x00000000.
+            drain_ext_payload(msg); // Re-sync the CDC stream.
             constexpr uint32_t err_payload = 0;
             send_harp_reply(WRITE_ERROR, msg.header.address,
                             &err_payload, sizeof(err_payload), reg_type_t::U32);
             return;
         }
+        bytes_received += uint32_t(chunk);
     }
-    const uint32_t computed_crc = crc ^ 0xFFFFFFFFu;
-    // Read and verify the 4-byte trailing CRC-32.
+    // All payload bytes received. Finalize CRC (header + payload only;
+    // the trailing CRC-32 field is excluded from the checksum calculation).
+    const uint32_t computed_crc = self->ext_crc32_state_ ^ 0xFFFFFFFFu;
+    // Read the 4-byte trailing CRC-32 directly (without updating CRC state).
     uint8_t crc_buf[4];
-    size_t crc_bytes_received = 0;
-    uint64_t crc_wait_start = time_us_64();
+    uint32_t crc_bytes_received = 0;
     while (crc_bytes_received < sizeof(crc_buf))
     {
         tud_task();
-        const size_t n = copy_ext_chunk(crc_buf + crc_bytes_received,
-                                        sizeof(crc_buf) - crc_bytes_received);
-        if (n > 0)
+        if ((time_us_64() - self->ext_last_chunk_us_) >= EXT_TIMEOUT_US)
         {
-            crc_bytes_received += n;
-            crc_wait_start = time_us_64();
-        }
-        else if ((time_us_64() - crc_wait_start) >= EXT_TIMEOUT_US)
-        {
-            // WRITE_ERROR for an extended-length write carries U32 0x00000000.
             constexpr uint32_t err_payload = 0;
             send_harp_reply(WRITE_ERROR, msg.header.address,
                             &err_payload, sizeof(err_payload), reg_type_t::U32);
             return;
+        }
+        const size_t n = tud_cdc_read(crc_buf + crc_bytes_received,
+                                      sizeof(crc_buf) - crc_bytes_received);
+        if (n > 0)
+        {
+            crc_bytes_received += uint32_t(n);
+            self->ext_last_chunk_us_ = time_us_64();
         }
     }
     uint32_t received_crc;
     memcpy(&received_crc, crc_buf, sizeof(received_crc));
     if (computed_crc != received_crc)
     {
-        // WRITE_ERROR for an extended-length write carries U32 0x00000000.
         constexpr uint32_t err_payload = 0;
         send_harp_reply(WRITE_ERROR, msg.header.address,
                         &err_payload, sizeof(err_payload), reg_type_t::U32);
@@ -647,7 +636,6 @@ void HarpCore::write_ext_reg_generic(extended_msg_t& msg)
     {
         // Reply payload is the CRC-32 of the request (receipt-CRC echo).
         send_harp_reply(WRITE, msg.header.address,
-                        &computed_crc, sizeof(computed_crc),
-                        reg_type_t::U32);
+                        &computed_crc, sizeof(computed_crc), reg_type_t::U32);
     }
 }

--- a/firmware/src/harp_core.cpp
+++ b/firmware/src/harp_core.cpp
@@ -175,7 +175,7 @@ void HarpCore::handle_buffered_core_message()
             core_reg_specs_[msg.header.address].read_fn_ptr(msg.header.address);
             break;
         case WRITE:
-            core_reg_specs_[msg.header.address].write_fn_ptr(msg);
+            reinterpret_cast<write_reg_fn>(core_reg_specs_[msg.header.address].write_fn_ptr)(msg);
             break;
     }
     clear_msg();

--- a/firmware/src/harp_core.cpp
+++ b/firmware/src/harp_core.cpp
@@ -25,7 +25,7 @@ HarpCore::HarpCore(uint16_t who_am_i,
        HARP_VERSION_MAJOR, HARP_VERSION_MINOR,
        fw_version_major, fw_version_minor, serial_number, name, tag},
  rx_buffer_index_{0}, total_bytes_read_{rx_buffer_index_},
- new_msg_{false}, new_ext_msg_{false},
+ new_msg_{false},
  set_visual_indicators_fn_{nullptr}, sync_{nullptr}, offset_us_64_{0},
  disconnect_handled_{false}, connect_handled_{false}, sync_handled_{false},
  heartbeat_interval_us_{HEARTBEAT_STANDBY_INTERVAL_US}
@@ -46,13 +46,6 @@ void HarpCore::run()
     update_state();
     update_app_state(); // Does nothing unless a derived class implements it.
     process_cdc_input();
-    if (new_ext_msg_)
-    {
-        handle_buffered_ext_app_message();
-        if (new_ext_msg_) // Safety net: clear if the handler forgot to.
-            clear_ext_msg();
-        return;
-    }
     if (not new_msg_)
         return;
 #ifdef DEBUG_HARP_MSG_IN
@@ -131,7 +124,7 @@ void HarpCore::process_cdc_input()
         if (rx_buffer_index_ >= sizeof(extended_msg_header_t))
         {
             rx_buffer_index_ = 0; // Reset index; header data stays in rx_buffer_.
-            new_ext_msg_ = true;
+            new_msg_ = true;
         }
         return; // Keep accumulating header bytes on the next call.
     }

--- a/firmware/src/harp_core.cpp
+++ b/firmware/src/harp_core.cpp
@@ -49,33 +49,39 @@ void HarpCore::run()
     if (not new_msg_)
         return;
 #ifdef DEBUG_HARP_MSG_IN
-    msg_t msg = get_buffered_msg();
-    printf("Msg data: \r\n");
-    printf("  type: %d\r\n", msg.header.type);
-    printf("  addr: %d\r\n", msg.header.address);
-    printf("  raw len: %d\r\n", msg.header.raw_length);
-    printf("  port: %d\r\n", msg.header.port);
-    printf("  payload type: %d\r\n", msg.header.payload_type);
-    printf("  payload len: %d\r\n", msg.header.payload_length());
-    uint8_t payload_len = msg.header.payload_length();
-    if (payload_len > 0)
+    if (get_buffered_msg_type() != msg_type_t::BLOB)
     {
-        printf("  payload: ");
-        for (auto i = 0; i < msg.payload_length(); ++i)
-            printf("%d, ", ((uint8_t*)(msg.payload))[i]);
+        msg_t msg = get_buffered_msg();
+        printf("Msg data: \r\n");
+        printf("  type: %d\r\n", msg.header.type);
+        printf("  addr: %d\r\n", msg.header.address);
+        printf("  raw len: %d\r\n", msg.header.raw_length);
+        printf("  port: %d\r\n", msg.header.port);
+        printf("  payload type: %d\r\n", msg.header.payload_type);
+        printf("  payload len: %d\r\n", msg.header.payload_length());
+        uint8_t payload_len = msg.header.payload_length();
+        if (payload_len > 0)
+        {
+            printf("  payload: ");
+            for (auto i = 0; i < msg.payload_length(); ++i)
+                printf("%d, ", ((uint8_t*)(msg.payload))[i]);
+        }
+        printf("\r\n\r\n");
     }
-    printf("\r\n\r\n");
 #endif
     // Handle in-range register msgs and clear them. Ignore out-of-range msgs.
     handle_buffered_core_message(); // Handle msg. Clear it if handled.
     if (not new_msg_)
         return;
-    handle_buffered_app_message(); // Handle msg. Clear it if handled.
+    if (get_buffered_msg_type() == msg_type_t::BLOB)
+        handle_buffered_ext_app_message(); // Handle msg. Clear it if handled.
+    else
+        handle_buffered_app_message(); // Handle msg. Clear it if handled.
     // Always clear any unhandled messages, so we don't lock up.
     if (new_msg_)
     {
 #ifdef DEBUG_HARP_MSG_IN
-    printf("Ignoring out-of-range msg!\r\n");
+        printf("Ignoring out-of-range msg!\r\n");
 #endif
         clear_msg();
     }
@@ -83,8 +89,8 @@ void HarpCore::run()
 
 void HarpCore::process_cdc_input()
 {
-    // Guard: preserve the extended-length header in rx_buffer_ while the handler is active.
-    if (new_ext_msg_)
+    // Guard: don't overwrite a buffered message that hasn't been handled yet.
+    if (new_msg_)
         return;
     if (not tud_cdc_available())
         return;

--- a/firmware/src/harp_core.cpp
+++ b/firmware/src/harp_core.cpp
@@ -26,6 +26,7 @@ HarpCore::HarpCore(uint16_t who_am_i,
        fw_version_major, fw_version_minor, serial_number, name, tag},
  rx_buffer_index_{0}, total_bytes_read_{rx_buffer_index_},
  new_msg_{false},
+ ext_crc32_state_{0}, ext_last_chunk_us_{0},
  set_visual_indicators_fn_{nullptr}, sync_{nullptr}, offset_us_64_{0},
  disconnect_handled_{false}, connect_handled_{false}, sync_handled_{false},
  heartbeat_interval_us_{HEARTBEAT_STANDBY_INTERVAL_US}
@@ -130,6 +131,11 @@ void HarpCore::process_cdc_input()
         if (rx_buffer_index_ >= sizeof(extended_msg_header_t))
         {
             rx_buffer_index_ = 0; // Reset index; header data stays in rx_buffer_.
+            // Seed CRC-32 over the 8-byte extended header so copy_ext_chunk()
+            // can accumulate payload bytes into the same running state.
+            ext_crc32_state_ = crc32_update(0xFFFFFFFFu, rx_buffer_,
+                                            sizeof(extended_msg_header_t));
+            ext_last_chunk_us_ = time_us_64();
             new_msg_ = true;
         }
         return; // Keep accumulating header bytes on the next call.
@@ -512,11 +518,22 @@ void HarpCore::read_uuid(uint8_t reg_name)
     send_harp_reply(READ, reg_name);
 }
 
-size_t HarpCore::copy_ext_chunk(void* dest, size_t max_bytes)
+bool HarpCore::copy_ext_chunk(void* dest, size_t max_bytes, size_t* bytes_written)
 {
-    if (max_bytes == 0 || !tud_cdc_available())
-        return 0;
-    return tud_cdc_read(dest, max_bytes);
+    tud_task();
+    if ((time_us_64() - self->ext_last_chunk_us_) >= EXT_TIMEOUT_US)
+    {
+        *bytes_written = 0;
+        return false; // Timeout.
+    }
+    *bytes_written = tud_cdc_read(dest, max_bytes);
+    if (*bytes_written > 0)
+    {
+        self->ext_crc32_state_ = crc32_update(self->ext_crc32_state_,
+                                               dest, *bytes_written);
+        self->ext_last_chunk_us_ = time_us_64();
+    }
+    return true;
 }
 
 void HarpCore::drain_ext_payload(extended_msg_t& msg)
@@ -532,7 +549,7 @@ void HarpCore::drain_ext_payload(extended_msg_t& msg)
         const uint32_t to_read = (remaining < sizeof(discard))
                                   ? remaining
                                   : uint32_t(sizeof(discard));
-        const size_t drained = copy_ext_chunk(discard, to_read);
+        const size_t drained = tud_cdc_read(discard, to_read);
         if (drained > 0)
         {
             remaining -= uint32_t(drained);

--- a/firmware/src/harp_core.cpp
+++ b/firmware/src/harp_core.cpp
@@ -586,8 +586,10 @@ void HarpCore::write_ext_reg_generic(extended_msg_t& msg)
         else if ((time_us_64() - last_progress_us) >= EXT_TIMEOUT_US)
         {
             drain_ext_payload(msg); // re-sync the CDC stream.
-            send_harp_reply(WRITE_ERROR, msg.header.address, nullptr, 0,
-                            msg.header.payload_type);
+            // WRITE_ERROR for an extended-length write carries U32 0x00000000.
+            constexpr uint32_t err_payload = 0;
+            send_harp_reply(WRITE_ERROR, msg.header.address,
+                            &err_payload, sizeof(err_payload), reg_type_t::U32);
             return;
         }
     }
@@ -608,8 +610,10 @@ void HarpCore::write_ext_reg_generic(extended_msg_t& msg)
         }
         else if ((time_us_64() - crc_wait_start) >= EXT_TIMEOUT_US)
         {
-            send_harp_reply(WRITE_ERROR, msg.header.address, nullptr, 0,
-                            msg.header.payload_type);
+            // WRITE_ERROR for an extended-length write carries U32 0x00000000.
+            constexpr uint32_t err_payload = 0;
+            send_harp_reply(WRITE_ERROR, msg.header.address,
+                            &err_payload, sizeof(err_payload), reg_type_t::U32);
             return;
         }
     }
@@ -617,8 +621,10 @@ void HarpCore::write_ext_reg_generic(extended_msg_t& msg)
     memcpy(&received_crc, crc_buf, sizeof(received_crc));
     if (computed_crc != received_crc)
     {
-        send_harp_reply(WRITE_ERROR, msg.header.address, nullptr, 0,
-                        msg.header.payload_type);
+        // WRITE_ERROR for an extended-length write carries U32 0x00000000.
+        constexpr uint32_t err_payload = 0;
+        send_harp_reply(WRITE_ERROR, msg.header.address,
+                        &err_payload, sizeof(err_payload), reg_type_t::U32);
         return;
     }
     if (!is_muted())


### PR DESCRIPTION
### Summary

Implements the device-side parser and write handler for the **ExtendedLength** flag introduced in [harp-tech/protocol#218](https://github.com/harp-tech/protocol/issues/218), along with the device-operation conventions from [harp-tech/protocol#221](https://github.com/harp-tech/protocol/issues/221) and the READ-request clarification from [harp-tech/protocol#219](https://github.com/harp-tech/protocol/issues/219). This lifts the 254-byte payload ceiling for app registers whose backing memory fits in RAM, without changing the wire format or behavior of any existing register.

Design context: [harp-tech/protocol discussions#222](https://github.com/orgs/harp-tech/discussions/222).

---

### Architecture

<img width="1491" height="1130" alt="extended-length-architecture" src="https://github.com/user-attachments/assets/cf08242c-1460-4dd8-991e-92e9bc5b698c" />

The above diagram covers the extended message wire format, the firmware data flow from `process_cdc_input()` through `write_ext_reg_generic()`, and the complete reply contract.

A brief summary of the data path:

```
USB CDC
  └─► process_cdc_input()
        ├─ [normal] existing path (unchanged)
        └─ [Type byte has bit 4 set]
              accumulate 8-byte extended_msg_header_t → new_ext_msg_ = true
                └─► run() → handle_buffered_ext_app_message()
                      ├─ bad address    → drain + WRITE_ERROR
                      ├─ READ|EXT flag  → drain + READ_ERROR  (#219)
                      ├─ no fn_ptr      → drain + WRITE_ERROR
                      └─ fn_ptr != null → fn(msg)
                              └─► write_ext_reg_generic()
                                    stream chunks → accumulate CRC-32
                                    verify trailing 4-byte CRC-32
                                    └─► WRITE reply (CRC echo, TimestampedU32)
```

---

### Known gaps / future work

- **Extended-length READ replies** — A regular READ to an extended-length register should reply with extended-length framing. Not yet implemented (clarification needed in #222).
- **Hardware CRC** — The Pico SDK DMA sniffer (mode `0x0`) implements IEEE 802.3 CRC-32. The current software `crc32_update()` can be swapped without API changes.
- **CRC optionality** — The SRM raised the possibility of dropping application-level CRC-32 altogether (redundant on USB bulk transport). If adopted, the trailing 4-byte field and `payload_length()` formula (`raw_length − 7`) would change.
- **Per-register echo muting** — A `mute_write_echo` flag in `RegSpec` is under consideration.
- **Overrun detection** — Deferred.